### PR TITLE
Remove spurrious newline

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,6 +119,6 @@ func checkBhEnv() {
 WARNING: BH_URL is set to https://bashhub.com on this machine
 If you will be running bashhub-client locally be sure to add
 export BH_URL=%v to your .bashrc or .zshrc`, internal.Addr)
-		fmt.Println(msg, "\n")
+		fmt.Println(msg)
 	}
 }


### PR DESCRIPTION
This fixes the following error:

```
cmd/root.go:122:3: Println arg list ends with redundant newline
?       github.com/nicksherron/bashhub-server   [no test files]
make: *** [test] Error 2
```