### PR TITLE
Docker image use database location in WORKDIR /data.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,3 +55,4 @@ WORKDIR /data
 EXPOSE 8080
 
 ENTRYPOINT ["bashhub-server"]
+CMD [ "--db", "./data.db"]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ bashhub-server
 
 2020/02/10 03:04:11 Listening and serving HTTP on http://0.0.0.0:8080
 ```
-or on docker 
+or on docker (backend database files are persisted in container volume `/data`)
 
 ```
 $ docker run -d -p 8080:8080 --name bashhub-server  nicksherron/bashhub-server 


### PR DESCRIPTION
Passes `--db ./data.db` to entrypoint `bashhub-server` as defaultarguments to persist database files in docker volume /data. Otherwise, the files reside in transient /root/.config/bashhub-server/ and are not persisted after the container is removed.